### PR TITLE
AdGeneration: Align segment parameter with OpenRTB spec(id必須, valueは非必須)

### DIFF
--- a/dev-docs/bidders/adgeneration.md
+++ b/dev-docs/bidders/adgeneration.md
@@ -31,7 +31,7 @@ If `ad-generation.jp` is specified for ortb2.site.content.data[].name and `546` 
 
 * segment[].id: Required. Must be a string.
 * segment[].value: Optional. Must be a string.
-* If only id is provided (e.g., { id: "1001" }), the id is treated as a pre-arranged classification code agreed upon with the publisher.
+* If only id is provided (e.g., { id: "1001" } or { id: "sports" }), the id field itself is treated as the segment value (e.g., an attribute or tag).
 * If both id and value are provided (e.g., { id: "news_category", value: "Sports_Sumo" }), the value is read as the value associated with the id (key).
 
 Example first party data that's available to all bidders and all adunits:
@@ -47,9 +47,10 @@ pbjs.setConfig({
                         segtax: 546
                     },
                     segment: [
-                        // Only id (required, string) is provided; treated as a classification code
-                        { id: "1001" }
-                        // Both id (required, string) and value (optional, string) are provided
+                        // Processed as a single segment value (attribute or tag)
+                        { id: "1001" },
+                        { id: "sports" },
+                        // Processed as Key-Value pairs
                         { id: "news_category", value: "Sports_Sumo" },
                         { id: "local_gourmet", value: "sushi" },
                         { id: "location", value: "tokyo" },

--- a/dev-docs/bidders/adgeneration.md
+++ b/dev-docs/bidders/adgeneration.md
@@ -27,8 +27,12 @@ In release 1.6.4 and later, publishers should use the `ortb2` method of setting 
 
 * ortb2.site.content.data[]
 
-If `ad-generation.jp` is specified for ortb2.site.content.data[].name and `546` is specified for ortb2.site.content.data[].ext.segtax,
-`ortb2.site.content.data[].segment[].name` and `ortb2.site.content.data[].segment[].value` can be any string value.
+If `ad-generation.jp` is specified for ortb2.site.content.data[].name and `546` is specified for ortb2.site.content.data[].ext.segtax, the segment array objects are processed as follows:
+
+* segment[].id: Required. Must be a string.
+* segment[].value: Optional. Must be a string.
+* If only id is provided (e.g., { id: "1001" }), the id is treated as a pre-arranged classification code agreed upon with the publisher.
+* If both id and value are provided (e.g., { id: "news_category", value: "Sports_Sumo" }), the value is read as the value associated with the id (key).
 
 Example first party data that's available to all bidders and all adunits:
 
@@ -43,9 +47,12 @@ pbjs.setConfig({
                         segtax: 546
                     },
                     segment: [
-                        { name: "news_category", value: "Sports_Sumo" },// name and value must be string types
-                        { name: "local_gourmet", value: "sushi" },
-                        { name: "location", value: "tokyo" }
+                        // Only id (required, string) is provided; treated as a classification code
+                        { id: "1001" }
+                        // Both id (required, string) and value (optional, string) are provided
+                        { id: "news_category", value: "Sports_Sumo" },
+                        { id: "local_gourmet", value: "sushi" },
+                        { id: "location", value: "tokyo" },
                     ]
                 }]
             }


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.

⚠️ The documentation is merged after the related code changes are merged and release ⚠️
-->

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)

## Background

This commit updates the AdGeneration bidder documentation (adgeneration.md) to address two issues related to First Party Data segments (ortb2.site.content.data[].segment).

### Align with OpenRTB Specification (Fix name to id)

The OpenRTB specification requires the id field for objects within data segment arrays (like site.content.data[].segment). The previous documentation example incorrectly used the name field.

This discrepancy caused valid FPD to be filtered out by Prebid's validationFpdModule, which correctly enforces the spec by rejecting segments lacking the required id field.

This commit replaces all instances of name with id in the example code to ensure compliance.

### Clarify Segment Handling Logic

The documentation is also updated to detail AdGeneration's specific handling of the segment object fields, reflecting a new publisher requirement:

segment[].id: Required.

segment[].value: Optional.

If only id is provided (e.g., { id: "1001" }): The id is treated as a pre-arranged classification code.

If both id and value are provided (e.g., { id: "news", value: "sports" }): The value is read as the value associated with the id (key).

The example code has been updated to demonstrate both of these use cases clearly. This ensures publishers understand how to send both key-value pairs and classification codes correctly.