### PR TITLE
AdGeneration: Align first-party data example with OpenRTB spec (id必須, valueは非必須)

### DIFF
--- a/dev-docs/bidders/adgeneration.md
+++ b/dev-docs/bidders/adgeneration.md
@@ -28,7 +28,7 @@ In release 1.6.4 and later, publishers should use the `ortb2` method of setting 
 * ortb2.site.content.data[]
 
 If `ad-generation.jp` is specified for ortb2.site.content.data[].name and `546` is specified for ortb2.site.content.data[].ext.segtax,
-`ortb2.site.content.data[].segment[].name` and `ortb2.site.content.data[].segment[].value` can be any string value.
+`ortb2.site.content.data[].segment[].id` and `ortb2.site.content.data[].segment[].value` can be any string value.
 
 Example first party data that's available to all bidders and all adunits:
 
@@ -43,9 +43,10 @@ pbjs.setConfig({
                         segtax: 546
                     },
                     segment: [
-                        { name: "news_category", value: "Sports_Sumo" },// name and value must be string types
-                        { name: "local_gourmet", value: "sushi" },
-                        { name: "location", value: "tokyo" }
+                        { id: "news_category", value: "Sports_Sumo" },// id and value must be string types
+                        { id: "local_gourmet", value: "sushi" },
+                        { id: "location", value: "tokyo" },
+                        { id: "code", value: "1001"}
                     ]
                 }]
             }


### PR DESCRIPTION
This PR updates the AdGeneration bidder documentation to align the first-party data example with the OpenRTB specification. The OpenRTB specification requires the `id` field for objects within the `user.data[].segment` array. However, the code example in the AdGeneration bidder documentation was incorrectly using the `name` field. This discrepancy causes valid first-party data to be filtered out by the `validationFpdModule`, as it correctly enforces the OpenRTB standard by rejecting segments that lack the required `id` field.
- In `dev-docs/bidders/adgeneration.md`, the `firstpartydata` example has been updated.
- The `name` key in the `segment` objects has been replaced with `id`. This change ensures the documentation provides a correct, compliant example for publishers, preventing potential integration issues.

<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.

⚠️ The documentation is merged after the related code changes are merged and release ⚠️
-->

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [x] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
- [ ] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
